### PR TITLE
Убираем привязку только к images

### DIFF
--- a/assets/plugins/pagebuilder/js/interaction.js
+++ b/assets/plugins/pagebuilder/js/interaction.js
@@ -271,7 +271,8 @@
                     if (thumb.match(/\.svg$/)) {
                         thumb = '../' + thumb;
                     } else {
-                        thumb = thumb.replace('assets/images/', '../assets/' + opts.thumbsDir + '/images/');
+                        thumb = thumb.replace('assets', '../assets');
+                        thumb = thumb.replace('/images/', '/' + opts.thumbsDir + '/images/');
                     }
 
                     if (source == '') {
@@ -295,7 +296,7 @@
                                 image.onerror = function() {
                                     if (this.thumbChecked == undefined) {
                                         this.thumbChecked = true;
-                                        this.src = source.replace('assets/images', '../assets/images');
+                                        this.src = source.replace('assets', '../assets');
                                     } else {
                                         $preview.css('background-image', 'url("../assets/images/noimage.jpg")');
                                     }


### PR DESCRIPTION
Если переопределить пути к файлам через ($_SESSION['KCFINDER']['uploadURL'], $_SESSION['KCFINDER']['assetsURL'], $_SESSION['KCFINDER']['uploadDir']), то пути до миниатюр прописываются не верные