### PR TITLE
Update pagebuilder.php

### DIFF
--- a/assets/plugins/pagebuilder/pagebuilder.php
+++ b/assets/plugins/pagebuilder/pagebuilder.php
@@ -15,6 +15,11 @@ class PageBuilder
     private $params;
     private $lang;
     private $iterations = [];
+    protected $richeditor;
+    protected $browser;
+    protected $table;
+    protected $isBackend;
+    protected $isTV;
 
     private $langAliases = [
         'bg' => 'bulgarian',


### PR DESCRIPTION
В PHP8.2 сыпятся варнинги на deprecated при использовании необъявленных свойств. Исправляем это.
![Firefox_Screenshot_2023-02-10T18-26-30 389Z](https://user-images.githubusercontent.com/12978365/218170289-28185bf7-1516-4cc0-8d3d-d6c4ae6e5074.png)
